### PR TITLE
Improved analytics and charts

### DIFF
--- a/client/src/components/ExpensesChart/index.tsx
+++ b/client/src/components/ExpensesChart/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import Paper from '@material-ui/core/Paper'
-import Button from '@material-ui/core/Button'
 
 import {
   Chart,
@@ -12,16 +11,14 @@ import {
   Tooltip,
   Title,
 } from '@devexpress/dx-react-chart-material-ui'
-import { withStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import NativeSelect from '@material-ui/core/NativeSelect'
 import FormControl from '@material-ui/core/FormControl'
 import { Animation } from '@devexpress/dx-react-chart'
 import { scaleBand } from '@devexpress/dx-chart-core'
 import { ArgumentScale, Stack } from '@devexpress/dx-react-chart'
-
-import { EventTracker } from '@devexpress/dx-react-chart';
-
+import { EventTracker } from '@devexpress/dx-react-chart'
 import {
   schemeCategory10,
   schemeAccent,
@@ -33,8 +30,10 @@ import {
   schemeSet2,
   schemeSet3,
 } from 'd3-scale-chromatic'
-
 import { Palette } from '@devexpress/dx-react-chart'
+
+import SwitchChartBtn from '../../components/SwitchChartBtn'
+import { ExpensesChartProps } from '../../types'
 
 const schemeCollection = [
   schemeCategory10,
@@ -48,12 +47,12 @@ const schemeCollection = [
   schemeSet3,
 ]
 
-const demoStyles = (theme: any) => ({
+const useStyles = makeStyles((theme: any) => ({
   root: {
     height: '200px',
   },
   chartContainer: {
-    height: '10rem'
+    height: '10rem',
   },
   typography: {
     marginTop: 0,
@@ -76,114 +75,122 @@ const demoStyles = (theme: any) => ({
   pieChart: {
     height: '5rem,',
   },
-})
+}))
 
-const ExpensesChart = (props: any) => {
+export default function ExpensesChart({
+  chartData,
+  year,
+  month,
+  valueField,
+  argumentField,
+  name
+}: ExpensesChartProps) {
   const [scheme, setScheme] = useState(schemeCollection[7])
 
   const changeScheme = (e: any) => {
     setScheme(schemeCollection[e.target.value])
   }
-  const { classes } = props
+  const classes = useStyles()
   const [switchChart, setSwitchChart] = useState(false)
+ 
   const switchChartView = () => {
     setSwitchChart(!switchChart)
   }
-  console.log('chart data', props.chartData)
-  console.log(props.name)
+
+  const pieChartText = 'Pie Chart'
+  const barChartText = 'Bar Chart'
+
+  console.log('chart data', chartData)
+  console.log(name)
   // console.log('values', props.valueField, 'arguments', props.argumentField)
   return (
     <Paper>
-      { switchChart ?
-       <Chart data={props.chartData}>
-       <ArgumentScale factory={scaleBand} />
-       <ArgumentAxis />
-       <ValueAxis />
-       
-        {/* <BarSeries
+      {switchChart ? (
+        <Chart data={chartData}>
+          <ArgumentScale factory={scaleBand} />
+          <ArgumentAxis />
+          <ValueAxis />
+
+          {/* <BarSeries
          valueField={props.valueField}
          argumentField={props.argumentField}
         name={props.name}
        /> */}
 
-       {
-         props.chartData.map((data: any) => (
-          <BarSeries
-          valueField={props.valueField}
-          argumentField={props.argumentField}
-         name={data.category}
-        />
-         ))
-       }
-      
-       
-       
-       <Stack />
-       <EventTracker />
-       <Tooltip />
-       <Legend />
-       <Title text={`Expenses Chart ${props.month} ${props.year}`} />
-       <Button variant="outlined" color="primary" onClick={switchChartView}>
-         Pie Chart
-       </Button>
-       <Animation /> 
-     </Chart>
-     :
-     <>
-     <Chart
-     data={props.chartData}
-   >
-     <Palette
-       scheme={scheme}
-       // name="category"
-     />
-     <PieSeries
-       valueField={props.valueField}
-       argumentField={props.argumentField}
-       name={props.name}
-     />
-     <Legend />
-     <Title text={`Expenses Chart ${props.month} ${props.year}`} />
-     <Button variant="outlined" color="primary" onClick={switchChartView}>
-         Bar Chart
-       </Button>
-     <EventTracker />
-     <Tooltip />
-     <Animation />
-   </Chart>
-   <div className={classes.schemeConteiner}>
-     {scheme.map((color) => (
-       <div
-         key={color}
-         className={classes.item}
-         style={{ backgroundColor: color }}
-       />
-     ))}
-   </div>
-   <div className={classes.div}>
-     <Typography component="h5" variant="h5" className={classes.typography}>
-       Scheme
-     </Typography>
-     <FormControl>
-       <NativeSelect onChange={changeScheme} defaultValue={0}>
-         <option value={0}>schemeCategory10</option>
-         <option value={1}>schemeAccent</option>
-         <option value={2}>schemeDark2</option>
-         <option value={3}>schemePaired</option>
-         <option value={4}>schemePastel1</option>
-         <option value={5}>schemePastel2</option>
-         <option value={6}>schemeSet1</option>
-         <option value={7}>schemeSet2</option>
-         <option value={8}>schemeSet3</option>
-       </NativeSelect>
-     </FormControl>
-   </div>
-   </>
-      }
-     
-     
+          { chartData.map((data: any) => (
+            <BarSeries
+              valueField={valueField}
+              argumentField={argumentField}
+              name={data.category}
+            />
+          ))}
+
+          <Stack />
+          <EventTracker />
+          <Tooltip />
+          <Legend />
+          <Title text={`Expenses Chart ${month} ${year}`} />
+          <SwitchChartBtn
+            switchChartView={switchChartView}
+            btnText={pieChartText}
+          />
+          <Animation />
+        </Chart>
+      ) : (
+        <>
+          <Chart data={chartData}>
+            <Palette
+              scheme={scheme}
+              // name="category"
+            />
+            <PieSeries
+              valueField={valueField}
+              argumentField={argumentField}
+              name={name}
+            />
+            <Legend />
+            <Title text={`Expenses Chart ${month} ${year}`} />
+            <SwitchChartBtn
+              switchChartView={switchChartView}
+              btnText={barChartText}
+            />
+            <EventTracker />
+            <Tooltip />
+            <Animation />
+          </Chart>
+          <div className={classes.schemeConteiner}>
+            {scheme.map((color) => (
+              <div
+                key={color}
+                className={classes.item}
+                style={{ backgroundColor: color }}
+              />
+            ))}
+          </div>
+          <div className={classes.div}>
+            <Typography
+              component="h5"
+              variant="h5"
+              className={classes.typography}
+            >
+              Scheme
+            </Typography>
+            <FormControl>
+              <NativeSelect onChange={changeScheme} defaultValue={0}>
+                <option value={0}>schemeCategory10</option>
+                <option value={1}>schemeAccent</option>
+                <option value={2}>schemeDark2</option>
+                <option value={3}>schemePaired</option>
+                <option value={4}>schemePastel1</option>
+                <option value={5}>schemePastel2</option>
+                <option value={6}>schemeSet1</option>
+                <option value={7}>schemeSet2</option>
+                <option value={8}>schemeSet3</option>
+              </NativeSelect>
+            </FormControl>
+          </div>
+        </>
+      )}
     </Paper>
   )
 }
-
-export default withStyles(demoStyles, { name: 'ExpensesChart' })(ExpensesChart)

--- a/client/src/components/IncomeExpensesMonthChart/index.tsx
+++ b/client/src/components/IncomeExpensesMonthChart/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Paper } from '@material-ui/core'
 import {
   ArgumentAxis,
@@ -12,15 +12,18 @@ import {
 import { EventTracker, Animation } from '@devexpress/dx-react-chart'
 import { scaleBand } from '@devexpress/dx-chart-core'
 import { ArgumentScale, Stack } from '@devexpress/dx-react-chart'
-import { makeStyles } from '@material-ui/core/styles'
 
+import { IncomeExpensesMonthChartProps } from '../../types'
 
-export default function IncomeExpensesMonthChart(props: any) {
-  console.log(props)
+export default function IncomeExpensesMonthChart({
+    data,
+    year,
+    month
+}: IncomeExpensesMonthChartProps) {
   
   return (
     <Paper className="chart-container">
-        <Chart data={props.data}>
+        <Chart data={data}>
           <ArgumentScale factory={scaleBand} />
           <ArgumentAxis />
           <ValueAxis />
@@ -34,7 +37,7 @@ export default function IncomeExpensesMonthChart(props: any) {
           <EventTracker />
           <Tooltip />
           <Legend />
-          <Title text={`Expenses/Income for ${props.month} ${props.year}`} />
+          <Title text={`Expenses/Income for ${month} ${year}`} />
           <Animation /> 
         </Chart>
      

--- a/client/src/components/IncomeExpensesYearChart/index.tsx
+++ b/client/src/components/IncomeExpensesYearChart/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { Paper } from '@material-ui/core'
-import Button from '@material-ui/core/Button'
 import {
   ArgumentAxis,
   ValueAxis,
@@ -14,28 +13,26 @@ import {
 import { EventTracker, Animation } from '@devexpress/dx-react-chart'
 import { scaleBand } from '@devexpress/dx-chart-core'
 import { ArgumentScale, Stack } from '@devexpress/dx-react-chart'
-import { makeStyles } from '@material-ui/core/styles'
 
-const useStyles = makeStyles((theme) => ({
-  switchChartBtn: {
-    padding: '.4rem',
-    cursor: 'pointer',
-    backgroundColor: 'blue',
-    color: 'white',
-  },
-}))
-export default function IncomeExpensesYearChart(props: any) {
-  console.log(props.data)
-  const classes = useStyles()
+import { IncomeExpensesYearChartProps } from '../../types'
+import SwitchChartBtn from '../../components/SwitchChartBtn'
+
+export default function IncomeExpensesYearChart({
+  data,
+  year,
+}: IncomeExpensesYearChartProps) {
+
   const [switchChart, setSwitchChart] = useState(false)
   const switchChartView = () => {
     setSwitchChart(!switchChart)
   }
+  const lineChartText = 'Line Chart'
+  const barChartText = 'Bar Chart'
 
   return (
     <Paper className="chart-container">
       {!switchChart ? (
-        <Chart data={props.data}>
+        <Chart data={data}>
           <ArgumentScale factory={scaleBand} />
           <ArgumentAxis />
           <ValueAxis />
@@ -49,14 +46,16 @@ export default function IncomeExpensesYearChart(props: any) {
           <EventTracker />
           <Tooltip />
           <Legend />
-          <Title text={`Expenses/Income for ${props.year}`} />
-          <Button variant="outlined" color="primary" onClick={switchChartView}>
-            Line Chart
-          </Button>
+          <Title text={`Expenses/Income for ${year}`} />
+          <SwitchChartBtn
+            switchChartView={switchChartView}
+            btnText={lineChartText}
+          />
+
           {/* <Animation /> */}
         </Chart>
       ) : (
-        <Chart data={props.data}>
+        <Chart data={data}>
           <ArgumentAxis />
           <ValueAxis />
           <SplineSeries
@@ -72,10 +71,12 @@ export default function IncomeExpensesYearChart(props: any) {
           <EventTracker />
           <Tooltip />
           <Legend />
-          <Title text={`Expenses/Income for ${props.year}`} />
-          <Button variant="outlined" color="primary" onClick={switchChartView}>
-            Bar Chart
-          </Button>
+          <Title text={`Expenses/Income for ${year}`} />
+          <SwitchChartBtn
+            switchChartView={switchChartView}
+            btnText={barChartText}
+          />
+
           {/* <Animation /> */}
         </Chart>
       )}

--- a/client/src/components/SwitchChartBtn/index.tsx
+++ b/client/src/components/SwitchChartBtn/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import EqualizerIcon from '@material-ui/icons/Equalizer';
+
+import { SwitchChartBtnProps } from '../../types'
+
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
+  extendedIcon: {
+    marginRight: theme.spacing(1),
+  },
+}))
+
+export default function SwitchChartBtn({
+  switchChartView,
+  btnText
+}: SwitchChartBtnProps) {
+  const classes = useStyles()
+  return (
+    <Button
+      variant="outlined"
+      color="primary"
+      className={classes.margin}
+      onClick={switchChartView}
+    > <span>
+      {btnText}
+      </span>
+      <EqualizerIcon />
+    </Button>
+  )
+}

--- a/client/src/hooks/useYearChart.ts
+++ b/client/src/hooks/useYearChart.ts
@@ -1,15 +1,12 @@
 import { useState, useEffect, useCallback } from 'react'
 
+import { YearChartData } from '../types'
 import { defaultYearChartData } from '../utils/defaultChartValues'
 
 export default function useYearChart(yearData: any) {
-  type YearChart = {
-    month: string
-    income: number
-    expenses: number
-  }
+ 
   const [err, setErr] = useState(null)
-  let [chartData, setChartData] = useState([] as YearChart[])
+  let [chartData, setChartData] = useState([] as YearChartData[])
   // this chart will show a comparison between expenses and income per year
   
   const loadChartData = 

--- a/client/src/hooks/useYearExpenses.ts
+++ b/client/src/hooks/useYearExpenses.ts
@@ -35,14 +35,13 @@ export default function useYearExpenses(selectedYear: number) {
 
   const changeYearView = useCallback(
     async (selectedYear: number) => {
-      console.log(selectedYear)
       try {
         const foundYear = await calendarData.years.find(
           (y: CalendarScheduler) => y.year === selectedYear
         )
-        console.log('found year', foundYear)
+        // console.log('found year', foundYear)
         //this does not update, same as in the Expense page with tileContent
-        setYearExpenses(foundYear)
+        // setYearExpenses(foundYear)
         // console.log('year different', foundYear.year, yearExpenses.year)
 
         // console.log('after update', yearExpenses)

--- a/client/src/pages/Analytics/index.tsx
+++ b/client/src/pages/Analytics/index.tsx
@@ -15,7 +15,6 @@ import useYearExpenses from '../../hooks/useYearExpenses'
 import useYearChart from '../../hooks/useYearChart'
 import IncomeExpensesYearChart from '../../components/IncomeExpensesYearChart'
 
-
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
@@ -58,8 +57,11 @@ const useStyles = makeStyles((theme) => ({
 export default function Analytics(props: any) {
   const classes = useStyles()
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight)
-  const isAuthenticated = useSelector((state: AppState) => state.user.isAuthenticated)
+  const isAuthenticated = useSelector(
+    (state: AppState) => state.user.isAuthenticated
+  )
   const user = useSelector((state: AppState) => state.user.user)
+  const calendarData = useSelector((state: AppState) => state.expenses.calendar)
   const [calendarDate] = useState(date)
   const [selectedYear, setSelectedYear] = useState(0)
   const [yearChart, setYearChart] = useState({} as CalendarScheduler)
@@ -68,32 +70,36 @@ export default function Analytics(props: any) {
     expensesData,
     yearViewExpenses,
     yearTotalExpenses,
-    avgYExpenses
+    avgYExpenses,
   ] = useYearExpenses(selectedYear)
 
- const [chartErr, chartData] = useYearChart(yearChart)
- console.log(chartData)
-//  console.log('year expenses', expensesData)
+  const [chartErr, chartData] = useYearChart(yearChart)
+  console.log(chartData)
+
+  console.log('year expenses', expensesData)
 
   useEffect(() => {
     if (!isAuthenticated) {
       props.history.push('/login')
     } else {
-        setSelectedYear(date.getFullYear())
-        setYearChart(expensesData)
+      setSelectedYear(date.getFullYear())
+      setYearChart(expensesData)
     }
   }, [isAuthenticated, props.history])
-  
+
   const onChange = async (e: any) => {
     try {
       const clickedYear = await e.getFullYear()
       setSelectedYear(clickedYear)
-      console.log(clickedYear)
-    } catch(err) {
-
-    } 
+      //at the moment this data and chart works only with changing the monthView from current month from here (current month), not with useExpense hook where we also set the total expenses. same code is present also in changeView function in hooks but it doesn't work
+      const foundYear = await calendarData.years.find(
+        (y: CalendarScheduler) => y.year === clickedYear
+      )
+      setYearChart(foundYear)
+    } catch (err) {
+      console.log(err)
+    }
   }
-  //at the moment this data and chart works only with the default month (current month), not with onChange
   return (
     <div className={classes.root}>
       <CssBaseline />
@@ -105,15 +111,15 @@ export default function Analytics(props: any) {
           <Grid container spacing={3} className={classes.grid}>
             <Grid item xs={5} md={4} lg={3}>
               <Paper className={fixedHeightPaper}>
-              {/* Total year expenses go hear */}
-              <h2>Expenses {yearViewExpenses.year}</h2>
-              <h4>Total {yearTotalExpenses}</h4>
-              <h4>Average {avgYExpenses} </h4> 
+                {/* Total year expenses go hear */}
+                <h2>Expenses {yearViewExpenses.year}</h2>
+                <h4>Total {yearTotalExpenses}</h4>
+                <h4>Average {avgYExpenses} </h4>
               </Paper>
             </Grid>
-             <Grid item xs={5} md={4} lg={3}>
+            <Grid item xs={5} md={4} lg={3}>
               <Paper className={fixedHeightPaper}>
-              <h2>Income </h2>
+                <h2>Income </h2>
                 {/* total year income goes here */}
                 <h4>Total</h4>
                 <h4>Average</h4>
@@ -121,22 +127,24 @@ export default function Analytics(props: any) {
             </Grid>
             <Grid item xs={5} md={6} lg={5}>
               <Paper className={fixedHeightPaper}>
-                <h3>{user.firstName} {user.lastName}</h3>
+                <h3>
+                  {user.firstName} {user.lastName}
+                </h3>
                 {/* year balance goes here */}
                 <h3>Total Balance</h3>
                 <h3>Year {selectedYear}</h3>
               </Paper>
             </Grid>
-             <Grid item xs={5} md={8} lg={8}>
+            <Grid item xs={5} md={8} lg={8}>
               {/*Expenses chart goes here, a series or bar chart for expenses and income for the year */}
               <Paper className={classes.chartHeightPaper}>
-                <IncomeExpensesYearChart data={chartData} year={selectedYear}/> 
+                <IncomeExpensesYearChart data={chartData} year={selectedYear} />
               </Paper>
             </Grid>
 
-             <Grid item xs={10} md={4}>
-                {/*Calendar for decade can goe here */}
-                <Calendar
+            <Grid item xs={10} md={4}>
+              {/*Calendar for decade can goe here */}
+              <Calendar
                 onChange={onChange}
                 value={calendarDate}
                 defaultView="decade"
@@ -151,4 +159,3 @@ export default function Analytics(props: any) {
     </div>
   )
 }
-

--- a/client/src/types/index.tsx
+++ b/client/src/types/index.tsx
@@ -125,6 +125,11 @@ export type AddIncomeBtnProps = {
   showFormOnClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
+export type SwitchChartBtnProps = {
+  switchChartView: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  btnText: string
+}
+
 export type CalendarScheduler = {
   years: any
   year: number
@@ -201,6 +206,39 @@ export type TotalExpensesYearProps = {
   year: number
   totalAmount: number
 }
+
+export type ExpensesChartData = {
+  category: string
+  amount: number
+}
+
+export type YearChartData = {
+  month: string
+  income: number
+  expenses: number
+}
+
+export type ExpensesChartProps = {
+  chartData: ExpensesChartData[]
+  year: number
+  month: string
+  valueField: string
+  argumentField: string
+  name: string
+}
+
+export type IncomeExpensesMonthChartProps = {
+  data: any
+  year: number
+  month: string 
+}
+
+export type IncomeExpensesYearChartProps = {
+  // data: YearChartData[] 
+  data: any
+  year: number
+} 
+
 export type AddExpenseBtnProps = {
   showFormOnClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }


### PR DESCRIPTION
`onChange` function on switch year view for chart working (only works from the component and not from `useYearExpenses` hook, although exactly the same code is written in there. Added `switchChartBtn` component, added `types` for all charts