### PR TITLE
Update analytics and totalIncome

### DIFF
--- a/client/src/components/SwitchAnalyticsViewBtn/index.tsx
+++ b/client/src/components/SwitchAnalyticsViewBtn/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+
+import { SwitchAnalyticsViewBtnProps } from '../../types/ui'
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
+  extendedIcon: {
+    marginRight: theme.spacing(1),
+  },
+}))
+
+export default function SwitchAnalyticsViewBtn({
+  switchAnalyticsView,
+  switchView,
+}: SwitchAnalyticsViewBtnProps) {
+  const classes = useStyles()
+
+  return (
+    <>
+      {switchView ? (
+        <Button
+          variant="contained"
+          size="small"
+          color="primary"
+          className={classes.margin}
+          onClick={switchAnalyticsView}
+        >
+          Switch to Year View
+        </Button>
+      ) : (
+        <Button
+          variant="contained"
+          size="small"
+          color="primary"
+          className={classes.margin}
+          onClick={switchAnalyticsView}
+        >
+          Switch to Month View
+        </Button>
+      )}
+    </>
+  )
+}

--- a/client/src/components/TotalIncome/index.tsx
+++ b/client/src/components/TotalIncome/index.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles({
 export default function TotalIncome({
   month,
   year,
-  income,
+  totalAmount,
 }: TotalIncomeProps) {
   return (
     <React.Fragment>
@@ -26,7 +26,7 @@ export default function TotalIncome({
         Total Income {month} {year}
       </Title>
       <Typography component="p" variant="h4">
-        {income}
+        {totalAmount}
       </Typography>
       <div>
       </div>

--- a/client/src/hooks/useMonthlyIncomeChart.ts
+++ b/client/src/hooks/useMonthlyIncomeChart.ts
@@ -18,7 +18,6 @@ export default function useMonthlyIncomeChart(monthlyIncomeData: any) {
       let benefitsTotal = 0
       let taxReturnTotal = 0
       let childAllowanceTotal = 0
-      console.log('monthlyData', monthlyData)
       if (!monthlyData || monthlyData.length < 1) {
         console.log('this is empty, chartData')
         setChartData([])
@@ -79,7 +78,7 @@ export default function useMonthlyIncomeChart(monthlyIncomeData: any) {
           const filterData = defaultMonthlyChartIncomesData.filter(
             (data) => data.amount > 0
           )
-          console.log('data after filtering', filterData)
+          // console.log('data after filtering', filterData)
           setChartData(filterData)
           // console.log('chart should update', chartData)
         }

--- a/client/src/hooks/useTotalMonthlyIncome.ts
+++ b/client/src/hooks/useTotalMonthlyIncome.ts
@@ -9,18 +9,18 @@ function useTotalMonthlyIncome(monthlyData: any) {
   const total = useSelector((state: AppState) => state.income.total)
   // console.log('total income from hooks', total)
   const [totalMonthlyIncome, setTotalMonthlyIncome] = useState(0)
-  console.log('from total monthly income', monthlyData)
+  // console.log('from total monthly income', monthlyData)
   useEffect(() => {
     dispatch(getTotalMonthlyIncome(monthlyData))
   }, [dispatch, monthlyData])
 
   useEffect(() => {
-    if (total) {
+    if (total !== undefined) {
       setTotalMonthlyIncome(total)
+      // console.log('from total monthly income', totalMonthlyIncome)
     }
   }, [total])
 
-  console.log('from total monthly income', totalMonthlyIncome)
   return [totalMonthlyIncome]
 }
 

--- a/client/src/hooks/useTotalMonthlyIncome.ts
+++ b/client/src/hooks/useTotalMonthlyIncome.ts
@@ -9,7 +9,7 @@ function useTotalMonthlyIncome(monthlyData: any) {
   const total = useSelector((state: AppState) => state.income.total)
   // console.log('total income from hooks', total)
   const [totalMonthlyIncome, setTotalMonthlyIncome] = useState(0)
-  console.log(monthlyData)
+  console.log('from total monthly income', monthlyData)
   useEffect(() => {
     dispatch(getTotalMonthlyIncome(monthlyData))
   }, [dispatch, monthlyData])
@@ -20,6 +20,7 @@ function useTotalMonthlyIncome(monthlyData: any) {
     }
   }, [total])
 
+  console.log('from total monthly income', totalMonthlyIncome)
   return [totalMonthlyIncome]
 }
 

--- a/client/src/hooks/useYearExpenses.ts
+++ b/client/src/hooks/useYearExpenses.ts
@@ -66,17 +66,13 @@ export default function useYearExpenses(selectedYear: number) {
   const calculateYearExpenses = useCallback(
     (data) => {
       let count = 0
-      //   console.log('expenses year', data)
       for (const month of data.months) {
         if (month.days.length > 0) {
           const { days } = month
-          //   console.log('these are not undefined', days)
           for (const day of days) {
-            // console.log(day)
             if (day.expenses.length > 0) {
               for (const expense of day.expenses) {
                 const { amount } = expense
-                // console.log('expense here', amount)
                 count += amount
               }
             }

--- a/client/src/pages/Analytics/index.tsx
+++ b/client/src/pages/Analytics/index.tsx
@@ -95,7 +95,7 @@ export default function Analytics(props: any) {
   ] = useMonthlyExpenses()
   const [totalExpenses] = useTotalMonthlyExpenses(monthlyData)
   const [totalIncome] = useTotalMonthlyIncome(monthlyData)
-  console.log('total income', totalIncome)
+  // console.log('total income', totalIncome)
   const [monthChartData, setMonthChartData] = useState([
     { month: '', income: 0, expenses: 0 },
   ])
@@ -113,8 +113,14 @@ export default function Analytics(props: any) {
       setDateView(defaultDateView)
       //testing the monthly data
       setMonthlyData(defaultMonth)
-      setMonthChartData([{ month: defaultDateView.month, income: totalIncome, expenses: totalExpenses }])
-      console.log(monthChartData)
+      setMonthChartData([
+        {
+          month: defaultDateView.month,
+          income: totalIncome,
+          expenses: totalExpenses,
+        },
+      ])
+      // console.log(monthChartData)
     }
   }, [isAuthenticated, props.history])
 
@@ -133,7 +139,6 @@ export default function Analytics(props: any) {
   }
 
   const onChangeMonth = async (e: any) => {
-    console.log(e.target)
     try {
       const selectedYear = await e.getFullYear()
       const currentIndex = await e.getMonth()
@@ -142,23 +147,17 @@ export default function Analytics(props: any) {
       //this is provisory
       dateView.year = selectedYear
       dateView.month = months[currentIndex]
-      console.log('date view here', dateView)
-
       const foundYear = await calendarData.years.find(
         (y: CalendarScheduler) => y.year === selectedYear
       )
       const foundMonth = await foundYear.months.find(
         (month: any) => month.name === months[currentIndex]
       )
-      console.log('found month here', foundMonth)
       setMonthlyData(foundMonth)
-      setMonthChartData([{ month: dateView.month, income: totalIncome, expenses: totalExpenses }])
-
-
-      
-
-    }
-    catch(err) {
+      setMonthChartData([
+        { month: dateView.month, income: totalIncome, expenses: totalExpenses },
+      ])
+    } catch (err) {
       console.log(err)
     }
   }
@@ -199,21 +198,21 @@ export default function Analytics(props: any) {
             </Grid>
             <Grid item xs={5} md={4} lg={3}>
               <Paper className={fixedHeightPaper}>
-                {
-                  switchView ? 
+                {switchView ? (
                   <TotalIncome
-                  year={year}
-                  month={month}
-                  income={totalIncome}
-                /> :
-                <>
-                 <h2>Income </h2>
-                {/* total year income goes here */}
-                <Typography component="p" variant="h4">
-                  €Total
-                </Typography>
-                </>
-                }   
+                    year={year}
+                    month={month}
+                    totalAmount={totalIncome}
+                  />
+                ) : (
+                  <>
+                    <h2>Income </h2>
+                    {/* total year income goes here */}
+                    <Typography component="p" variant="h4">
+                      €Total
+                    </Typography>
+                  </>
+                )}
               </Paper>
             </Grid>
             <Grid item xs={5} md={6} lg={5}>
@@ -233,26 +232,23 @@ export default function Analytics(props: any) {
             <Grid item xs={5} md={8} lg={8}>
               {/*Expenses chart goes here, a series or bar chart for expenses and income for the year */}
               <Paper className={classes.chartHeightPaper}>
-                {
-                  switchView ?
+                {switchView ? (
                   <IncomeExpensesMonthChart
-                  data={monthChartData}
-                  year={year}
-                  month={month}                
-                  /> 
-                  :
-                <IncomeExpensesYearChart
-                data={yearChartData}
-                year={selectedYear}
-              />
-
-                }
-               
+                    data={monthChartData}
+                    year={year}
+                    month={month}
+                  />
+                ) : (
+                  <IncomeExpensesYearChart
+                    data={yearChartData}
+                    year={selectedYear}
+                  />
+                )}
               </Paper>
             </Grid>
 
             <Grid item xs={10} md={4}>
-              {/*Calendar for decade can goe here */}
+              {/*Calendar for year and decade can go here */}
               {switchView ? (
                 <Calendar
                   onChange={onChangeMonth}

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -10,7 +10,6 @@ import Paper from '@material-ui/core/Paper'
 import Typography from "@material-ui/core/Typography";
 
 import { AppState, ViewMonth } from '../../types'
-import { date } from '../../utils/dateValues'
 import TotalExpenses from '../../components/TotalExpenses'
 import TotalIncome from '../../components/TotalIncome'
 import useMonthlyExpenses from '../../hooks/useMonthlyExpenses'
@@ -86,7 +85,6 @@ export default function Dashboard(props: any) {
     } else {
       setMonthlyData(defaultMonth)
       setMonthChartData([{ month: defaultDateView.month, income: totalIncome, expenses: totalExpenses }])
-      // console.log('should update', monthChartData)
     }
   }, [isAuthenticated, props.history, setMonthChartData, totalExpenses])
 

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -118,7 +118,7 @@ export default function Dashboard(props: any) {
                 <TotalIncome
                   year={year}
                   month={month}
-                  income={totalIncome}
+                  totalAmount={totalIncome}
                 />
               </Paper>
             </Grid>

--- a/client/src/pages/Income/index.tsx
+++ b/client/src/pages/Income/index.tsx
@@ -9,7 +9,7 @@ import Container from '@material-ui/core/Container'
 import Grid from '@material-ui/core/Grid'
 import Paper from '@material-ui/core/Paper'
 
-import { AppState, CalendarScheduler, DateView } from '../../types'
+import { AppState, CalendarScheduler, DateView, ViewMonth } from '../../types'
 import useMonthlyIncomeChart from '../../hooks/useMonthlyIncomeChart'
 import EmptyChartContainer from '../../components/EmptyChartContainer'
 import { Income } from '../../types/income'
@@ -19,6 +19,7 @@ import TotalIncome from '../../components/TotalIncome'
 import ProfileDashboard from '../../components/ProfileDashboard'
 import { months } from '../../utils/dateValues'
 import IncomeMonthlyChart from '../../components/IncomeMonthlyChart'
+import useTotalMonthlyIncome from '../../hooks/useTotalMonthlyIncome'
 import 'react-calendar/dist/Calendar.css'
 import './style.css'
 
@@ -67,7 +68,9 @@ export default function IncomePage(props: any) {
   const [isFormShowing, setIsFormShowing] = useState(false)
   const [monthlyChart, setMonthlyChart] = useState([])
   const [monthIncome, setMonthIncome] = useState([] as Income[])
-  const [incomeChartData] = useMonthlyIncomeChart(monthlyChart)
+  const [monthlyData, setMonthlyData] = useState(
+    ([] as unknown) as ViewMonth
+  )
   const [
     err,
     incomeData,
@@ -75,6 +78,9 @@ export default function IncomePage(props: any) {
     calendarData,
     defaultMonth,
   ] = useIncome()
+  const [incomeChartData] = useMonthlyIncomeChart(monthlyChart)
+  const [totalIncome] = useTotalMonthlyIncome(monthlyData)
+  console.log('total income from page', totalIncome)
   const [loaded, setIsLoaded] = useState(false)
   const [dateView, setDateView] = useState({
     year: 0,
@@ -89,6 +95,8 @@ export default function IncomePage(props: any) {
       if (!isMonthClicking) {
         //atm the below set state keeps running an infinite loop
         setDateView(defaultDateView as DateView)
+        setMonthlyData(defaultMonth)
+        // console.log('monthly data', monthlyData)
         setMonthlyChart(defaultMonth?.income as any)
       }
     }
@@ -105,6 +113,8 @@ export default function IncomePage(props: any) {
     )
     setMonthIncome(foundMonth?.income)
     setMonthlyChart(foundMonth.income)
+    setMonthlyData(foundMonth)
+    // console.log('monthly data', monthlyData)
     setIsLoaded(true)
     // }, 150)
   }
@@ -137,7 +147,7 @@ export default function IncomePage(props: any) {
     setDateView({ ...dateView, year: year, month: months[currentIndex] })
     changeMonthView(dateView.year, dateView.month, yearIncome, currentIndex)
   }
-
+/*
   const calculateTotalIncome = () => {
     let count = 0
     for (const income of incomeData) {
@@ -151,9 +161,9 @@ export default function IncomePage(props: any) {
     if (incomeData !== undefined) {
       calculateTotalIncome()
     }
-  }, [incomeData, calculateTotalIncome])
+  }, [incomeData, calculateTotalIncome])*/
 
-  const income = calculateTotalIncome()
+  // const income = calculateTotalIncome()
 
   return (
     <div className={classes.root}>
@@ -188,13 +198,13 @@ export default function IncomePage(props: any) {
                 <TotalIncome
                   year={dateView.year}
                   month={dateView.month}
-                  income={income}
+                  totalAmount={totalIncome}
                 />
               </Paper>
             </Grid>
             <Grid item xs={5} md={4} lg={3}>
               <Paper className={fixedHeightPaper}>
-                <ProfileDashboard income={income} />
+                {/* <ProfileDashboard income={income} /> */}
               </Paper>
             </Grid>
             <Grid item xs={12} md={6} lg={6}>
@@ -210,11 +220,11 @@ export default function IncomePage(props: any) {
             </Grid>
             <Grid item xs={10} md={6} lg={6}>
               <Calendar
-                onChange={onChange}
+                // onChange={onChange}
                 value={calendarDate}
                 showNeighboringMonth={true}
-                onClickYear={showYearOnClick}
-                onClickMonth={showMonthOnClick}
+                // onClickYear={showYearOnClick}
+                onChange={showMonthOnClick}
                 defaultView="year"
                 maxDetail="year"
                 // tileContent={({ date, view }) => showExpenseOnCalendar(date, view)}

--- a/client/src/redux/actions/income.ts
+++ b/client/src/redux/actions/income.ts
@@ -143,9 +143,8 @@ export function getTotalMonthlyIncome(monthlyData: any) {
     try {
       let count: any = 0
       if (monthlyData !== undefined) {
-        console.log('from getTotalMonthlyIncome action', monthlyData)
+        // console.log('from getTotalMonthlyIncome action', monthlyData)
         for (const income of monthlyData.income) {
-          console.log(income)
           const { amount } = income
             count += amount
         }

--- a/client/src/redux/reducers/income.ts
+++ b/client/src/redux/reducers/income.ts
@@ -35,7 +35,6 @@ export default function income(
     case DELETE_INCOME:
     case UPDATE_INCOME:
       const { income } = action.payload
-      console.log('from reducer', income)
       return {
         ...state,
         income: income,

--- a/client/src/types/income.ts
+++ b/client/src/types/income.ts
@@ -63,7 +63,7 @@ export type IncomeTableProps = {
 export type TotalIncomeProps = {
   month: string
   year: number
-  income: number
+  totalAmount: number
 }
 
 export type totalMonthlyIncome = {

--- a/client/src/types/ui.ts
+++ b/client/src/types/ui.ts
@@ -64,3 +64,8 @@ export type ExpensesChartProps = {
   className?: string
 }
 
+export type SwitchAnalyticsViewBtnProps = {
+  switchAnalyticsView:  (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  switchView: boolean
+}
+


### PR DESCRIPTION
updated analytics with a switch month/year functionality. user can switch between year calendar and monthly calendar and view totalIncome and totalExpenses with both chart. monthly chart for income and expenses is buggy and needs to be clicked twice. Fixed TotalIncome component and redux which was getting props from a function in the Income page, it takes now the state from redux